### PR TITLE
feat: Enum 별로 스프링 빈 매핑하기

### DIFF
--- a/kopring/src/main/kotlin/com/example/kopring/user/UserType.kt
+++ b/kopring/src/main/kotlin/com/example/kopring/user/UserType.kt
@@ -1,0 +1,64 @@
+package com.example.kopring.user
+
+import com.example.kopring.member.domain.MemberRepository
+import com.example.kopring.member.service.MemberService
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import javax.annotation.PostConstruct
+
+enum class UserType {
+    A_USER,
+    B_USER,
+    C_USER;
+
+    private lateinit var userService: UserService
+
+    private fun settingService(userService: UserService) {
+        this.userService = userService
+    }
+
+    fun run(): String {
+        if (::userService.isInitialized) {
+            return this.userService.run("goodall")
+        } else {
+            throw IllegalStateException("설정안된 Service 가 있습니다. ${this.name}")
+        }
+    }
+
+    @Component
+    class UserServiceInjector(
+        private val aUserService: AUserService,
+        private val bUserService: BUserService,
+    ) {
+
+        @PostConstruct
+        fun postConstruct() {
+            A_USER.settingService(aUserService)
+            B_USER.settingService(bUserService)
+        }
+    }
+}
+
+interface UserService {
+    fun run(string: String): String
+}
+
+@Service
+class AUserService(
+    private val memberRepository: MemberRepository,
+) : UserService {
+
+    override fun run(string: String): String {
+        return "AUserService $string"
+    }
+}
+
+@Service
+class BUserService(
+    private val memberService: MemberService,
+) : UserService {
+
+    override fun run(string: String): String {
+        return "BUserService $string"
+    }
+}

--- a/kopring/src/test/kotlin/com/example/kopring/user/UserTypeTest.kt
+++ b/kopring/src/test/kotlin/com/example/kopring/user/UserTypeTest.kt
@@ -1,0 +1,28 @@
+package com.example.kopring.user
+
+import com.example.kopring.test.IntegrationTest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+@IntegrationTest
+class UserTypeTest {
+
+    @Test
+    fun test1() {
+        UserType.A_USER.run() shouldBe "AUserService goodall"
+    }
+
+    @Test
+    fun test2() {
+        UserType.B_USER.run() shouldBe "BUserService goodall"
+    }
+
+    @Test
+    fun test3() {
+        shouldThrowExactly<IllegalStateException>{
+            UserType.C_USER.run()
+        }.message shouldBe "설정안된 Service 가 있습니다. C_USER"
+    }
+}


### PR DESCRIPTION
- `@PostConstruct` 를 이용
- 스프링이 로드된뒤, Enum 내의 필드에 값을 주입하여 Enum 별로 스프링 빈을 들고 있게 하는 예시 입니다.